### PR TITLE
simple-hooter

### DIFF
--- a/app/assets/stylesheets/modules/_simple-footer.scss
+++ b/app/assets/stylesheets/modules/_simple-footer.scss
@@ -1,0 +1,33 @@
+.simple-footer{
+  width: 456px;
+  height: 220px;
+  margin: 0 auto;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  padding: 40px 0;
+  text-align: center;
+  background-color: whitesmoke;
+  color: #333;
+  ul{
+    font-size: 0;
+    li{
+      margin: 10px;
+      display: inline-block;
+      font-size: 12px;
+    }
+  }
+  &__logo{
+    img{
+      margin-top: 20px;
+    }
+  }
+  p{
+    margin-top: 10px;
+  }
+  small {
+    font-size: 13px;
+  }
+}

--- a/app/views/layouts/_simple-footer.html.haml
+++ b/app/views/layouts/_simple-footer.html.haml
@@ -1,0 +1,10 @@
+.footer.simple-footer
+  %nav
+    %ul.clearfix
+      %li プライバシーポリシー
+      %li メルカリ利用規約
+      %li 特定商取引に関する表記
+  %a.footer__mein__logo{:href => "/"}
+    %img{:alt => "mercari", :height => "65", :src => "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?465897195", :width => "80"}/
+  %p
+    %small © 2019 Mercari


### PR DESCRIPTION
<h2>what</h2>
・ログイン画面と商品画面のフッターの余白の修正、テキストサイズの修正
・フッターのパーシャル化（クラス名 simple-footer）

<h2>why</h2>
フッターの下の余白が大きかったため。パーシャル化は他にも使えるかもしれないので。