### PR TITLE
seeds.rbのproductsデータ保存の記述を変更

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -361,9 +361,10 @@ if Rails.env == "development"
   10.times do |i|
     Product.create!(
       name: "ほげほげ#{i + 1}",
-      price: 8600,
-      size: 25,
-      condition: "きれい"
-    )
+      price: 8600, 
+      size: 25, 
+      condition: 3, 
+      category_id: 1
+      )
   end
 end


### PR DESCRIPTION
## what
以下の記述を修正および追加
・condition: 3　　
・category_id: 1

## why
・rake db:seedでデータ作成時のエラーを解消
・condition: 3　　→　conditionカラムがINT型に変更されたため
・category_id: 1　→　categoryテーブルとのアソシエーションに対応
