### PR TITLE
マイグレーション時のエラーを解決

### DIFF
--- a/db/migrate/20191115061828_add_seller_id_to_products.rb
+++ b/db/migrate/20191115061828_add_seller_id_to_products.rb
@@ -1,7 +1,7 @@
 class AddSellerIdToProducts < ActiveRecord::Migration[5.0]
   def change
-    add_column :products, :seller_id, :integer, :null=>false
-    add_column :products, :bland_id, :integer
-    add_column :products, :buyer_id, :integer
+    change_column :products, :seller_id, :integer, :null=>false
+    change_column :products, :bland_id, :integer
+    change_column :products, :buyer_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20191115061828) do
+ActiveRecord::Schema.define(version: 20191116084258) do
 
   create_table "cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",     null: false
@@ -60,8 +59,8 @@ ActiveRecord::Schema.define(version: 20191115061828) do
     t.integer  "region"
     t.integer  "category_id"
     t.integer  "seller_id",                      null: false
-    t.integer  "bland_id"
     t.integer  "buyer_id"
+    t.integer  "bland_id"
     t.index ["buyer_id"], name: "index_products_on_buyer_id", using: :btree
     t.index ["seller_id"], name: "index_products_on_seller_id", using: :btree
   end


### PR DESCRIPTION
## What
・AddSellerIdToProductsのadd_coloum〜をchange_coloum〜に変更
## Why
・rake db:migrate時のエラーを解決